### PR TITLE
Adding matplotlib

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -10,3 +10,4 @@ dependencies:
     - fastp=0.20.0
     - trimmomatic=0.39
     - pandas=0.25.1
+    - matplotlib=3.3.0


### PR DESCRIPTION
`matplotlib` is required in the conda environment to make this work.