### PR TITLE
added fasten + github actions + some bugs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,21 +7,33 @@ jobs:
     strategy:
       fail-fast: true
     steps:
+      - name: build-env
+        run: |
+          echo "CORES=$(nproc)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
-      - name: conda
-        run: |
-          echo "$CONDA/bin" >> "$GITHUB_PATH"
-          $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
-      - name: test env
-        run: |
-          which snakemake
-          snakemake --help
-          snakemake --version
-      - name: benchmarks
-        run: |
-          CORES=$(nproc)
-          snakemake --use-conda --jobs $CORES
+      #- name: conda
+      #  run: |
+      #    echo "$CONDA/bin" >> "$GITHUB_PATH"
+      #    $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
+      #- name: test env
+      #  run: |
+      #    which snakemake
+      #    snakemake --help
+      #    snakemake --version
+      - name: benchmark with snakemake
+        uses: snakemake/snakemake-github-action@v1
+        with:
+          directory: .test
+          snakefile: "workflow/Snakefile"
+          args: "--jobs $CORES --use-conda"
+          show-disk-usage-on-error:true
+      #- name: benchmarks
+      #  run: |
+      #    CORES=$(nproc)
+      #    snakemake --use-conda --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks
-          path: output/**
+          path: |
+            .test/**
+            output/**

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,16 +11,21 @@ jobs:
         run: |
           echo "CORES=$(nproc)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
-      - name: benchmark with snakemake
-        uses: snakemake/snakemake-github-action@v1
-        with:
-          directory: .test
-          snakefile: "workflow/Snakefile"
-          args: "--jobs ${{ fromJSON(env.CORES) }} --use-conda"
-          show-disk-usage-on-error: true
+      - name: conda
+        run: |
+          echo "$CONDA/bin" >> "$GITHUB_PATH"
+          $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
+      - name: test env
+        run: |
+          which snakemake
+          snakemake --help
+          snakemake --version
+      - name: benchmarks
+        run: |
+          echo "variable CORES: '$CORES'"
+          snakemake --use-conda --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks
           path: |
-            .test/**
             output/**

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       - name: conda
         run: |
           echo "$CONDA/bin" >> "$GITHUB_PATH"
-          $CONDA/bin/conda install snakemake -y -c bioconda
+          $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
           which snakemake
       - name: test env
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           directory: .test
           snakefile: "workflow/Snakefile"
-          args: "--jobs $CORES --use-conda"
+          args: "--jobs ${{ fromJSON(env.CORES) }} --use-conda"
           show-disk-usage-on-error: true
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       - name: benchmarks
         run: |
           echo "variable CORES: '$CORES'"
-          snakemake --use-conda --scheduler simple --jobs $CORES
+          snakemake --use-conda --scheduler greedy --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       - name: benchmarks
         run: |
           echo "variable CORES: '$CORES'"
-          snakemake --use-conda --jobs $CORES
+          snakemake --use-conda --scheduler simple --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       - name: conda
         run: |
           echo "$CONDA/bin" >> "$GITHUB_PATH"
-          $CONDA/bin/conda install snakemake -y
+          $CONDA/bin/conda install snakemake -y -c bioconda
           which snakemake
       - name: test env
         run: |
@@ -20,4 +20,7 @@ jobs:
         run: |
           CORES=$(nproc)
           snakemake --use-conda --jobs $CORES
-           
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks
+          path: output/**

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
           directory: .test
           snakefile: "workflow/Snakefile"
           args: "--jobs $CORES --use-conda"
-          show-disk-usage-on-error:true
+          show-disk-usage-on-error: true
       #- name: benchmarks
       #  run: |
       #    CORES=$(nproc)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,21 +11,12 @@ jobs:
         run: |
           echo "CORES=$(nproc)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
-      #- name: conda
-      #  run: |
-      #    echo "$CONDA/bin" >> "$GITHUB_PATH"
-      #    $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
-      #- name: test env
-      #  run: |
-      #    which snakemake
-      #    snakemake --help
-      #    snakemake --version
       - name: benchmark with snakemake
         uses: snakemake/snakemake-github-action@v1
         with:
           directory: .test
           snakefile: "workflow/Snakefile"
-          args: "--jobs $CORES --use-conda"
+          args: "--jobs 4 --use-conda"
           show-disk-usage-on-error: true
       #- name: benchmarks
       #  run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       - name: benchmarks
         run: |
           echo "variable CORES: '$CORES'"
-          snakemake --use-conda --scheduler greedy --jobs 1
+          snakemake --use-conda --scheduler greedy --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       - name: benchmarks
         run: |
           echo "variable CORES: '$CORES'"
-          snakemake --use-conda --scheduler greedy --jobs $CORES
+          snakemake --use-conda --scheduler greedy --jobs 1
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,12 +16,8 @@ jobs:
         with:
           directory: .test
           snakefile: "workflow/Snakefile"
-          args: "--jobs 4 --use-conda"
+          args: "--jobs $CORES --use-conda"
           show-disk-usage-on-error: true
-      #- name: benchmarks
-      #  run: |
-      #    CORES=$(nproc)
-      #    snakemake --use-conda --jobs $CORES
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,10 +12,11 @@ jobs:
         run: |
           echo "$CONDA/bin" >> "$GITHUB_PATH"
           $CONDA/bin/conda install snakemake -y -c bioconda -c conda-forge
-          which snakemake
       - name: test env
         run: |
           which snakemake
+          snakemake --help
+          snakemake --version
       - name: benchmarks
         run: |
           CORES=$(nproc)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,23 @@
+on: push
+name: benchmark
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: conda
+        run: |
+          echo "$CONDA/bin" >> "$GITHUB_PATH"
+          $CONDA/bin/conda install snakemake -y
+          which snakemake
+      - name: test env
+        run: |
+          which snakemake
+      - name: benchmarks
+        run: |
+          CORES=$(nproc)
+          snakemake --use-conda --jobs $CORES
+           

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.snakemake
+output

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following tools are compared:
  - [Cutadapt](https://cutadapt.readthedocs.io/en/stable/)
  - [Fastp](https://github.com/OpenGene/fastp)
  - [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic)
+ - [Fasten](https://github.com/lskatz/fasten)
 
 ## Fake adapters, "gruseq"
 The comparison adds fake truseq adapters, "gruseq", provided by Brian Bushnell,
@@ -34,4 +35,3 @@ Run the benchmarking workflow with something like:
 ```bash
 snakemake --use-conda --jobs 10
 ```
-

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -31,8 +31,8 @@ rule download_fastq:
         fastq=FASTQ
     shell:
         """
-        wget --output-document {output} {params.fastq}
-        gunzip -c {output} | head -n 888888 | gzip -c9 > tmp.fastq
+        wget --output-document {output} {params.fastq} && \
+        gunzip -c {output} | head -n 888888 | gzip -c9 > tmp.fastq && \
         mv tmp.fastq {output}
         """
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,14 +29,13 @@ rule all:
 
 rule generate_fastq:
     output:
-        directory("output"),
         "output/random.fastq.gz"
     conda: "envs/main.yaml"
     params:
         num_reads=100000,
         seq_length=100
     run:
-        with open(output[1], "wt") as outfile:
+        with open(output[0], "wt") as outfile:
             for i in range(params.num_reads):
                 seq = ''.join(random.choices("ACGT", k=params.seq_length))
                 qual = ''.join(random.choices("IJKLMNOPQRSTUVWXYZ", k=params.seq_length))
@@ -46,11 +45,11 @@ rule download_fastq:
     output:
         "output/data.fastq.gz"
     conda: "envs/main.yaml"
-    params:
-        random_fastq=rules.generate_fastq.output[1]
+    input:
+        random_fastq=rules.generate_fastq.output[0]
     shell:
         """
-        cp -v {params.random_fastq} {output}
+        cp -v {input.random_fastq} {output}
         """
 
 rule add_adapters:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -12,6 +12,7 @@ TOOLS=[
     "bbduk",
     "fastp",
     "adapterremoval",
+    "fasten",
 ]
 FASTQ="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR921/004/SRR9218144/SRR9218144.fastq.gz"
 
@@ -60,7 +61,7 @@ rule cutadapt:
         "output/processed/cutadapt.fq"
     log: "output/logs/cutadapt.log"
     conda: "envs/cutadapt.yaml"
-    threads: 10
+    threads: 1
     benchmark:
         repeat("output/benchmarks/cutadapt.benchmark.txt", 3)
     shell:
@@ -97,6 +98,26 @@ rule cutadapt:
             2> {log}
         """
 
+rule fasten:
+    input:
+        fastq=rules.add_adapters.output,
+        adapters="gruseq.fa",
+    output:
+        "output/processed/fasten.fq"
+    conda: "envs/fasten.yaml"
+    log: "output/logs/fasten.log"
+    threads: 1
+    benchmark:
+        repeat("output/benchmarks/fasten.benchmark.txt", 3)
+    shell:
+        """
+        fasten \
+          --adapterseqs {input.adapters} \
+          < {input.fastq} \
+          > {output} \
+          2> {log}
+        """
+        
 rule trimmomatic:
     input:
         fastq=rules.add_adapters.output,
@@ -105,7 +126,7 @@ rule trimmomatic:
         "output/processed/trimmomatic.fq"
     conda: "envs/trimmomatic.yaml"
     log: "output/logs/trimmomatic.log"
-    threads: 10
+    threads: 1
     benchmark:
         repeat("output/benchmarks/trimmomatic.benchmark.txt", 3)
     shell:
@@ -130,7 +151,7 @@ rule bbduk:
         "output/processed/bbduk.fq"
     conda: "envs/main.yaml"
     log: "output/logs/bbduk.log"
-    threads: 10
+    threads: 1
     benchmark:
         repeat("output/benchmarks/bbduk.benchmark.txt", 3)
     shell:
@@ -157,7 +178,7 @@ rule fastp:
         json="output/processed/fastp.json",
     conda: "envs/fastp.yaml"
     log: "output/logs/fastp.log"
-    threads: 10
+    threads: 1
     benchmark:
         repeat("output/benchmarks/fastp.benchmark.txt", 3)
     shell:
@@ -181,7 +202,7 @@ rule adapterremoval:
         fq="output/processed/adapterremoval.fq",
     conda: "envs/adapterremoval.yaml"
     log: "output/logs/adapterremoval.log"
-    threads: 10
+    threads: 1
     shadow: "shallow"
     benchmark:
         repeat("output/benchmarks/adapterremoval.benchmark.txt", 3)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -32,6 +32,8 @@ rule download_fastq:
     shell:
         """
         wget --output-document {output} {params.fastq}
+        zcat {output} | head -n 888888 | gzip -c9 > tmp.fastq
+        mv tmp.fastq {output}
         """
 
 rule add_adapters:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -15,6 +15,7 @@ TOOLS=[
     "fasten",
 ]
 FASTQ="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR921/004/SRR9218144/SRR9218144.fastq.gz"
+replicates=1
 
 rule all:
     input:
@@ -38,7 +39,7 @@ rule add_adapters:
         fastq=rules.download_fastq.output,
         adapters="gruseq.fa",
     output:
-        "output/dirty.fq"
+        "output/dirty.fq.gz"
     log: "output/logs/add_adapters.log"
     conda: "envs/main.yaml"
     shell:
@@ -51,6 +52,12 @@ rule add_adapters:
             right \
             int=f \
             2> {log}
+        cat output/dirty.fq | \
+            paste - - - - | \
+            head -n 78999 | \
+            sort -k2,2 | \
+            tr '\t' '\n' | \
+            gzip -c > {output}
         """
 
 rule cutadapt:
@@ -63,10 +70,11 @@ rule cutadapt:
     conda: "envs/cutadapt.yaml"
     threads: 1
     benchmark:
-        repeat("output/benchmarks/cutadapt.benchmark.txt", 3)
+        repeat("output/benchmarks/cutadapt.benchmark.txt", replicates)
     shell:
         """
-        cutadapt \
+        gunzip -c {input.fastq} | \
+            cutadapt \
             --cores {threads} \
             --minimum-length 10 \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATGATACTGAGACGTGCAACGAGGAGCAGGC \
@@ -93,7 +101,7 @@ rule cutadapt:
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATACTCGCCTGTGAGACGTGCAACGAGGAGCAGGC \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATAGCTGTGTGAGACGTGCAACGAGGAGCAGGC \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATGGAAGGGTGAGACGTGCAACGAGGAGCAGGC \
-            {input.fastq} \
+            - \
             > {output} \
             2> {log}
         """
@@ -108,10 +116,11 @@ rule fasten:
     log: "output/logs/fasten.log"
     threads: 1
     benchmark:
-        repeat("output/benchmarks/fasten.benchmark.txt", 3)
+        repeat("output/benchmarks/fasten.benchmark.txt", replicates)
     shell:
         """
-        fasten \
+        gunzip -c {input.fastq} | \
+          fasten_trim \
           --adapterseqs {input.adapters} \
           < {input.fastq} \
           > {output} \
@@ -128,7 +137,7 @@ rule trimmomatic:
     log: "output/logs/trimmomatic.log"
     threads: 1
     benchmark:
-        repeat("output/benchmarks/trimmomatic.benchmark.txt", 3)
+        repeat("output/benchmarks/trimmomatic.benchmark.txt", replicates)
     shell:
         """
         trimmomatic \
@@ -153,7 +162,7 @@ rule bbduk:
     log: "output/logs/bbduk.log"
     threads: 1
     benchmark:
-        repeat("output/benchmarks/bbduk.benchmark.txt", 3)
+        repeat("output/benchmarks/bbduk.benchmark.txt", replicates)
     shell:
         """
         bbduk.sh \
@@ -180,7 +189,7 @@ rule fastp:
     log: "output/logs/fastp.log"
     threads: 1
     benchmark:
-        repeat("output/benchmarks/fastp.benchmark.txt", 3)
+        repeat("output/benchmarks/fastp.benchmark.txt", replicates)
     shell:
         """
         fastp \
@@ -205,11 +214,12 @@ rule adapterremoval:
     threads: 1
     shadow: "shallow"
     benchmark:
-        repeat("output/benchmarks/adapterremoval.benchmark.txt", 3)
+        repeat("output/benchmarks/adapterremoval.benchmark.txt", replicates)
     shell:
         """
-        AdapterRemoval \
-            --file1 {input.fastq} \
+        gunzip -c {input.fastq} | \
+            AdapterRemoval \
+            --file1 - \
             --output1 {output.fq} \
             --adapter-list {input.adapters} \
             --thread {threads} \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,6 +6,9 @@
 #   http://seqanswers.com/forums/attachment.php?attachmentid=2993&d=1398383571
 # Fredrik Boulund 2019
 
+import random
+import gzip
+
 TOOLS=[
     "cutadapt",
     "trimmomatic",
@@ -19,22 +22,35 @@ replicates=3
 
 rule all:
     input:
+        #"output/data.fastq.gz"
         expand("output/grades/{tool}.grade.txt", tool=TOOLS),
         expand("output/plots/{plot}.pdf", plot=["benchmarks", "grades"]),
-        
+
+
+rule generate_fastq:
+    output:
+        directory("output"),
+        "output/random.fastq.gz"
+    conda: "envs/main.yaml"
+    params:
+        num_reads=100000,
+        seq_length=100
+    run:
+        with open(output[1], "wt") as outfile:
+            for i in range(params.num_reads):
+                seq = ''.join(random.choices("ACGT", k=params.seq_length))
+                qual = ''.join(random.choices("IJKLMNOPQRSTUVWXYZ", k=params.seq_length))
+                outfile.write(f"@read{i}\n{seq}\n+\n{qual}\n")
 
 rule download_fastq:
     output:
         "output/data.fastq.gz"
     conda: "envs/main.yaml"
     params:
-        fastq=FASTQ,
-        tmpfile="output/tmp.fastq.gz"
+        random_fastq=rules.generate_fastq.output[1]
     shell:
         """
-        wget --output-document {output} {params.fastq} && \
-        gunzip -c {output} | head -n 888888 | gzip -c9 > {params.tmpfile} && \
-        mv {params.tmpfile} {output}
+        cp -v {params.random_fastq} {output}
         """
 
 rule add_adapters:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -46,7 +46,8 @@ rule download_fastq:
         "output/data.fastq.gz"
     conda: "envs/main.yaml"
     input:
-        random_fastq=rules.generate_fastq.output[0]
+        #random_fastq=rules.generate_fastq.output[0]
+        random_fastq="data/SRR9218144.888888.fastq.gz"
     shell:
         """
         cp -v {input.random_fastq} {output}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -46,7 +46,7 @@ rule add_adapters:
         """
         addadapters.sh \
             in={input.fastq} \
-            out={output} \
+            out=output/dirty.fq \
             qout=33 \
             ref={input.adapters} \
             right \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -15,7 +15,7 @@ TOOLS=[
     "fasten",
 ]
 FASTQ="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR921/004/SRR9218144/SRR9218144.fastq.gz"
-replicates=1
+replicates=3
 
 rule all:
     input:
@@ -39,25 +39,19 @@ rule add_adapters:
         fastq=rules.download_fastq.output,
         adapters="gruseq.fa",
     output:
-        "output/dirty.fq.gz"
+        "output/dirty.fq"
     log: "output/logs/add_adapters.log"
     conda: "envs/main.yaml"
     shell:
         """
         addadapters.sh \
             in={input.fastq} \
-            out=output/dirty.fq \
+            out={output} \
             qout=33 \
             ref={input.adapters} \
             right \
             int=f \
-            2> {log} && \
-        cat output/dirty.fq | \
-            paste - - - - | \
-            head -n 78999 | \
-            sort -k2,2 | \
-            tr '\t' '\n' | \
-            gzip -c > {output}
+            2> {log}
         """
 
 rule cutadapt:
@@ -73,8 +67,7 @@ rule cutadapt:
         repeat("output/benchmarks/cutadapt.benchmark.txt", replicates)
     shell:
         """
-        gunzip -c {input.fastq} | \
-            cutadapt \
+        cutadapt \
             --cores {threads} \
             --minimum-length 10 \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATGATACTGAGACGTGCAACGAGGAGCAGGC \
@@ -101,32 +94,11 @@ rule cutadapt:
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATACTCGCCTGTGAGACGTGCAACGAGGAGCAGGC \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATAGCTGTGTGAGACGTGCAACGAGGAGCAGGC \
             --anywhere CTGACCTTCTCATATACGAGCTTAGAATCGATATGGAAGGGTGAGACGTGCAACGAGGAGCAGGC \
-            - \
+            {input.fastq} \
             > {output} \
             2> {log}
         """
 
-rule fasten:
-    input:
-        fastq=rules.add_adapters.output,
-        adapters="gruseq.fa",
-    output:
-        "output/processed/fasten.fq"
-    conda: "envs/fasten.yaml"
-    log: "output/logs/fasten.log"
-    threads: 1
-    benchmark:
-        repeat("output/benchmarks/fasten.benchmark.txt", replicates)
-    shell:
-        """
-        gunzip -c {input.fastq} | \
-          fasten_trim \
-          --adapterseqs {input.adapters} \
-          < {input.fastq} \
-          > {output} \
-          2> {log}
-        """
-        
 rule trimmomatic:
     input:
         fastq=rules.add_adapters.output,
@@ -217,9 +189,8 @@ rule adapterremoval:
         repeat("output/benchmarks/adapterremoval.benchmark.txt", replicates)
     shell:
         """
-        gunzip -c {input.fastq} | \
-            AdapterRemoval \
-            --file1 - \
+        AdapterRemoval \
+            --file1 {input.fastq} \
             --output1 {output.fq} \
             --adapter-list {input.adapters} \
             --thread {threads} \
@@ -258,3 +229,24 @@ rule plot:
             {input.grades}
         """
 
+
+
+rule fasten:
+    input:
+        fastq=rules.add_adapters.output,
+        adapters="gruseq.fa",
+    output:
+        "output/processed/fasten.fq"
+    conda: "envs/fasten.yaml"
+    log: "output/logs/fasten.log"
+    threads: 1
+    benchmark:
+        repeat("output/benchmarks/fasten.benchmark.txt", replicates)
+    shell:
+        """
+        fasten_trim \
+          --adapterseqs {input.adapters} \
+          < {input.fastq} \
+          > {output} \
+          2> {log};
+        """

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -32,7 +32,7 @@ rule download_fastq:
     shell:
         """
         wget --output-document {output} {params.fastq}
-        zcat {output} | head -n 888888 | gzip -c9 > tmp.fastq
+        gunzip -c {output} | head -n 888888 | gzip -c9 > tmp.fastq
         mv tmp.fastq {output}
         """
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -51,7 +51,7 @@ rule add_adapters:
             ref={input.adapters} \
             right \
             int=f \
-            2> {log}
+            2> {log} && \
         cat output/dirty.fq | \
             paste - - - - | \
             head -n 78999 | \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -28,7 +28,7 @@ rule download_fastq:
         "output/data.fastq.gz"
     conda: "envs/main.yaml"
     params:
-        fastq=FASTQ
+        fastq=FASTQ,
         tmpfile="output/tmp.fastq.gz"
     shell:
         """

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,11 +29,12 @@ rule download_fastq:
     conda: "envs/main.yaml"
     params:
         fastq=FASTQ
+        tmpfile="output/tmp.fastq.gz"
     shell:
         """
         wget --output-document {output} {params.fastq} && \
-        gunzip -c {output} | head -n 888888 | gzip -c9 > tmp.fastq && \
-        mv tmp.fastq {output}
+        gunzip -c {output} | head -n 888888 | gzip -c9 > {params.tmpfile} && \
+        mv {params.tmpfile} {output}
         """
 
 rule add_adapters:

--- a/workflow/envs/fasten.yaml
+++ b/workflow/envs/fasten.yaml
@@ -1,0 +1,6 @@
+name: fasten
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - fasten=0.8.5


### PR DESCRIPTION
* Addresses #5 by giving equal footing with 1 thread each
* Addresses #4 by adding `fasten_trim`
* Adds a github action which publishes the graphs onto the Actions tab
* Adds a fastq file to the repo, truncated from the original fastq file, to make testing faster
